### PR TITLE
Fix PDA derivations and parsing

### DIFF
--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -29,7 +29,7 @@ export class AgentCommands {
 
         try {
           let capabilities = options.capabilities
-            ? parseInt(options.capabilities)
+            ? parseInt(options.capabilities, 10)
             : 0;
           let metadataUri = options.metadata || "";
 
@@ -182,7 +182,7 @@ export class AgentCommands {
 
           const updateOptions: any = {};
           if (options.capabilities) {
-            updateOptions.capabilities = parseInt(options.capabilities);
+            updateOptions.capabilities = parseInt(options.capabilities, 10);
           }
           if (options.metadata) {
             updateOptions.metadataUri = options.metadata;
@@ -225,7 +225,7 @@ export class AgentCommands {
 
           const client = await createClient(globalOpts.network);
 
-          const agents = await client.getAllAgents(parseInt(options.limit));
+          const agents = await client.getAllAgents(parseInt(options.limit, 10));
 
           if (agents.length === 0) {
             spinner.succeed("No agents found");

--- a/cli/src/commands/channel.ts
+++ b/cli/src/commands/channel.ts
@@ -34,8 +34,8 @@ export class ChannelCommands {
           let name = options.name;
           let description = options.description;
           let visibility = options.visibility as ChannelVisibility;
-          let maxParticipants = parseInt(options.maxParticipants);
-          let feePerMessage = parseInt(options.fee);
+          let maxParticipants = parseInt(options.maxParticipants, 10);
+          let feePerMessage = parseInt(options.fee, 10);
 
           if (options.interactive) {
             const answers = await inquirer.prompt([
@@ -218,11 +218,11 @@ export class ChannelCommands {
             const wallet = getWallet(globalOpts.keypair);
             channels = await client.getChannelsByCreator(
               wallet.publicKey,
-              parseInt(options.limit),
+              parseInt(options.limit, 10),
             );
           } else {
             channels = await client.getAllChannels(
-              parseInt(options.limit),
+              parseInt(options.limit, 10),
               options.visibility as ChannelVisibility,
             );
           }
@@ -441,7 +441,7 @@ export class ChannelCommands {
 
           const participants = await client.getChannelParticipants(
             new PublicKey(channelId),
-            parseInt(options.limit),
+            parseInt(options.limit, 10),
           );
 
           if (participants.length === 0) {
@@ -498,7 +498,7 @@ export class ChannelCommands {
 
           const messages = await client.getChannelMessages(
             new PublicKey(channelId),
-            parseInt(options.limit),
+            parseInt(options.limit, 10),
           );
 
           if (messages.length === 0) {

--- a/cli/src/commands/escrow.ts
+++ b/cli/src/commands/escrow.ts
@@ -85,7 +85,7 @@ export class EscrowCommands {
             if (options.amount) {
               amount = solToLamports(parseFloat(options.amount));
             } else if (options.lamports) {
-              amount = parseInt(options.lamports);
+              amount = parseInt(options.lamports, 10);
             } else {
               console.error(
                 chalk.red(
@@ -214,7 +214,7 @@ export class EscrowCommands {
               if (options.amount) {
                 amount = solToLamports(parseFloat(options.amount));
               } else if (options.lamports) {
-                amount = parseInt(options.lamports);
+                amount = parseInt(options.lamports, 10);
               } else {
                 console.error(
                   chalk.red(
@@ -361,7 +361,7 @@ export class EscrowCommands {
 
           const escrows = await client.getEscrowsByDepositor(
             wallet.publicKey,
-            parseInt(options.limit),
+            parseInt(options.limit, 10),
           );
 
           if (escrows.length === 0) {

--- a/cli/src/commands/message.ts
+++ b/cli/src/commands/message.ts
@@ -42,7 +42,7 @@ export class MessageCommands {
           let payload = options.payload;
           let messageType = options.type as MessageType;
           let customValue = options.customValue
-            ? parseInt(options.customValue)
+            ? parseInt(options.customValue, 10)
             : 0;
 
           if (options.interactive) {
@@ -310,7 +310,7 @@ export class MessageCommands {
 
           const messages = await client.getAgentMessages(
             agentAddress,
-            parseInt(options.limit),
+            parseInt(options.limit, 10),
             options.filter as MessageStatus,
           );
 

--- a/tests/pod-com-clean.test.ts
+++ b/tests/pod-com-clean.test.ts
@@ -9,7 +9,7 @@ import {
   LAMPORTS_PER_SOL,
 } from "@solana/web3.js";
 import { expect, test, beforeAll, describe } from "bun:test";
-import { MessageType, findAgentPDA, findMessagePDA } from "./test-utils";
+import { findAgentPDA, findMessagePDA } from "./test-utils";
 
 // Configure the client to use the local cluster.
 const provider = anchor.AnchorProvider.env();
@@ -44,7 +44,7 @@ describe("POD-COM Clean Tests", () => {
     });
 
     // Initialize PDAs
-    [agentPDA] = findAgentPDA(testWallet.publicKey);
+    [agentPDA] = findAgentPDA(testWallet.publicKey, program.programId);
   });
 
   test("can register a test agent", async () => {
@@ -75,6 +75,7 @@ describe("POD-COM Clean Tests", () => {
       testWallet.publicKey,
       PAYLOAD_HASH,
       messageType,
+      program.programId,
     );
 
     const tx = await program.methods

--- a/tests/pod-com.test.ts
+++ b/tests/pod-com.test.ts
@@ -38,8 +38,8 @@ let messagePDA: PublicKey;
 describe("POD-COM Tests", () => {
   beforeAll(async () => {
     // Initialize PDAs
-    [senderAgentPDA] = findAgentPDA(wallet.publicKey);
-    [recipientAgentPDA] = findAgentPDA(wallet.publicKey); // Use same wallet to avoid airdrop
+    [senderAgentPDA] = findAgentPDA(wallet.publicKey, program.programId);
+    [recipientAgentPDA] = findAgentPDA(wallet.publicKey, program.programId); // Use same wallet to avoid airdrop
   });
 
   test("can register a sender agent", async () => {
@@ -86,7 +86,7 @@ describe("POD-COM Tests", () => {
     // Use agent PDA as that's what gets stored in message.sender and used for PDA calculation
     [messagePDA] = findMessagePDA(
       senderAgentPDA,
-      wallet.publicKey,
+      recipientAgentPDA,
       PAYLOAD_HASH,
       messageType,
       program.programId,


### PR DESCRIPTION
### **User description**
## Summary
- fix findAgentPDA and findMessagePDA calls in tests
- remove unused MessageType import
- parse CLI numeric flags with explicit radix

## Testing
- `npm test` *(fails: anchor not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4245cb188330aac7ee2ebf2d2767


___

### **PR Type**
Bug fix


___

### **Description**
• Fix PDA derivation calls by adding missing `programId` parameter
• Add explicit radix parameter to `parseInt` calls for safer parsing
• Remove unused `MessageType` import from test file
• Correct message PDA recipient parameter in test


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Add radix parameter to parseInt calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/agent.ts

• Add explicit radix (10) to <code>parseInt</code> calls for capabilities and limit <br>options<br> • Ensures consistent decimal parsing across agent <br>registration, update, and list operations


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/POD-COM/pull/5/files#diff-4644dc53e26591e12748e185f87e907333cb9d6f1cf094ccc5d86334ffbe6cc1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>channel.ts</strong><dd><code>Add radix parameter to parseInt calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/channel.ts

• Add explicit radix (10) to all <code>parseInt</code> calls for numeric options<br> • <br>Affects maxParticipants, feePerMessage, and limit parameters


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/POD-COM/pull/5/files#diff-488e192e063e738a9ad341aba7747da1222be7e730ec1bc13df4455ba0b61ad1">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>escrow.ts</strong><dd><code>Add radix parameter to parseInt calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/escrow.ts

• Add explicit radix (10) to <code>parseInt</code> calls for lamports and limit <br>options<br> • Ensures consistent decimal parsing in escrow operations


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/POD-COM/pull/5/files#diff-06ad6f3292193092acc587b720f1569441a7da378928a6cd71e551944232d4d9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>message.ts</strong><dd><code>Add radix parameter to parseInt calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/commands/message.ts

• Add explicit radix (10) to <code>parseInt</code> calls for customValue and limit <br>options<br> • Ensures consistent decimal parsing in message operations


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/POD-COM/pull/5/files#diff-5372bba2c63a20362f1b2e3ec1858f04cefb63d150032425f9302e43ac2e7438">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pod-com-clean.test.ts</strong><dd><code>Fix PDA function calls and imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/pod-com-clean.test.ts

• Remove unused <code>MessageType</code> import<br> • Add missing <code>programId</code> parameter <br>to <code>findAgentPDA</code> and <code>findMessagePDA</code> calls


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/POD-COM/pull/5/files#diff-5db9ba4886c395097fd990414fbe4d778a92e471bd6a76eb828a038efe6f4db0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pod-com.test.ts</strong><dd><code>Fix PDA function calls and parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/pod-com.test.ts

• Add missing <code>programId</code> parameter to <code>findAgentPDA</code> calls<br> • Fix <br><code>findMessagePDA</code> recipient parameter from <code>wallet.publicKey</code> to <br><code>recipientAgentPDA</code>


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/POD-COM/pull/5/files#diff-0fb2c8fa3854ef4731d55c51b22e5a187db7b2fe2a849ce308cb447673af08d2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of number parsing in command-line options by ensuring all numeric inputs are consistently interpreted as decimal values across agent, channel, escrow, and message commands.

- **Tests**
	- Updated test utilities to explicitly pass the program ID when deriving addresses, ensuring more accurate and consistent test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->